### PR TITLE
Fix short tag on helper

### DIFF
--- a/third_party/purge/helpers/varnish_helper.php
+++ b/third_party/purge/helpers/varnish_helper.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 


### PR DESCRIPTION
When saving an entry on a system that does not have PHP short-tags
enabled, the extension dies with "Fatal error: Call to undefined function
send_purge_request()". To fix this, replace the short-tag with a full tag
in the varnish_helper.php file.
