### PR TITLE
specify url in accessory

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ If you click into modules > Purge you can now set URL patterns to purge when ent
 
 ## Changelog
 
+* **1.1.1 - March 13, 2015**
+	* Added support for MSM for URLs patterns in Purge Addon Admin settings. Can specify manual URLs in accessory. 
 * **1.1 - February 13, 2015**
 	* Changed addon to only purge via url patterns when entries are saved. All cache can still be purged using the accessory. 
 * **1.0.4 - March 17, 2014**

--- a/third_party/purge/acc.purge.php
+++ b/third_party/purge/acc.purge.php
@@ -51,6 +51,9 @@ class Purge_acc
 	{
 		if (AJAX_REQUEST)
 		{
+			
+			
+			
 			$EE =& get_instance();
 			$EE->load->helper('varnish');
 			$urls = $EE->config->item('varnish_site_url');
@@ -63,7 +66,17 @@ class Purge_acc
 			
 			foreach ($urls as $url)
 			{
-				send_purge_request($url, $port);
+				if($_POST['purge_url'] != '')
+					$_url = preg_replace('/\/$/','',$url).'/'.preg_replace('/^\//','',$_POST['purge_url']); //handle trailing and beginning slashes
+				else 
+					$_url = $url;
+				$resp = send_purge_request($_url, $port);
+				
+				echo $resp; //depending on curl to send varnish's response or an error
+				
+				die; //we die here instead of return to cut of template debugging 
+				
+				
 			}
 		}
 	}

--- a/third_party/purge/acc.purge.php
+++ b/third_party/purge/acc.purge.php
@@ -64,20 +64,22 @@ class Purge_acc
 				$urls = array($urls);
 			}
 			
+			$resp = ''; //if using multiple varnish servers, collect responses in here seperated by line break
+			
 			foreach ($urls as $url)
 			{
+				if(strlen($resp)>0) $resp .= "\n"; //if already captured other responses put in a line break
+				
 				if($_POST['purge_url'] != '')
 					$_url = preg_replace('/\/$/','',$url).'/'.preg_replace('/^\//','',$_POST['purge_url']); //handle trailing and beginning slashes
 				else 
 					$_url = $url;
-				$resp = send_purge_request($_url, $port);
-				
-				echo $resp; //depending on curl to send varnish's response or an error
-				
-				die; //we die here instead of return to cut of template debugging 
-				
-				
+					
+				$resp .= send_purge_request($_url, $port); //depending on curl to send varnish's response or an error
+							
 			}
+			
+			die($resp); //we die here instead of return to cut of template debugging 
 		}
 	}
 }

--- a/third_party/purge/ext.purge.php
+++ b/third_party/purge/ext.purge.php
@@ -89,7 +89,7 @@ class Purge_ext
 	 */
 	public function send_purge_request($id,$meta,$data)
 	{
-		
+
 		$this->EE->load->helper('varnish');
 		
  		$urls = $this->site_url;
@@ -102,6 +102,7 @@ class Purge_ext
 		//get patterns for this channel
 		$this->EE->db->select('*');
 		$this->EE->db->where('channel_id',(int) $meta['channel_id']);
+		$this->EE->db->where('site_id',(int) $meta['site_id']);
 		$channelPatterns = $this->EE->db->get_where('purge_rules')->result_array();
 		
 		//if no patterns this may mean patterns aren't configured therefore revert to old behaviour of clearing everything 

--- a/third_party/purge/helpers/varnish_helper.php
+++ b/third_party/purge/helpers/varnish_helper.php
@@ -32,13 +32,21 @@ if ( ! function_exists('send_purge_request'))
 		curl_setopt($ch, CURLOPT_URL, $purge_url);
 		curl_setopt($ch, CURLOPT_PORT , (int)$port);
 		curl_setopt($ch, CURLOPT_HTTPHEADER, array( 'Host: '.$_SERVER['SERVER_NAME'] ) );
+		curl_setopt($ch, CURLOPT_ENCODING , "gzip");
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST,'PURGE');
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT ,2); 
 		curl_setopt($ch, CURLOPT_TIMEOUT, 4);
-		if(curl_exec($ch) === false)
-			die( curl_error ( $ch ) ); 
+		$resp = curl_exec($ch);
+		
+		if(curl_errno($ch) > 1) //should be 0 but for some reason my curl complains about error 1, protocol unrecognised but request still processes.
+			$resp = curl_error($ch);
+				
 		curl_close ($ch);
+		
+		preg_match("/<p>([^<]*)<\/p>/",$resp,$resp); //extract the core message from typical varnish response. 
+		
+		return $resp[1];
 	}
 }
 

--- a/third_party/purge/mcp.purge.php
+++ b/third_party/purge/mcp.purge.php
@@ -4,10 +4,8 @@
  
 class Purge_mcp {
 	
-	public $return_data;
-	public $return_array = array();
 	private $_base_url;
-
+	private $_site_id; 
 	
 	
 	/**
@@ -18,6 +16,7 @@ class Purge_mcp {
 		$this->EE =& get_instance();
 		
 		$this->_base_url = BASE.AMP.'C=addons_modules'.AMP.'M=show_module_cp'.AMP.'module=purge';
+		$this->_site_id = (int) $this->EE->config->item('site_id');
 		
 		$this->EE->cp->set_right_nav(array(
 			'module_home'	=> $this->_base_url
@@ -49,7 +48,9 @@ class Purge_mcp {
 	
 	private function get()
 	{
+		
 		$this->EE->db->select('*');
+		$this->EE->db->where('site_id', $this->_site_id);
 		return $this->EE->db->get_where('purge_rules')->result_array();
 	}
 	
@@ -64,7 +65,7 @@ class Purge_mcp {
 		
 		foreach($rules as $key => $channel)
 		{
-			$this->EE->db->insert( 'purge_rules', array('channel_id' => $channel, 'pattern' => $patterns[$key]) );	
+			$this->EE->db->insert( 'purge_rules', array('site_id' => $this->_site_id, 'channel_id' => $channel, 'pattern' => $patterns[$key]) );	
 		}
 
 		$this->EE->functions->redirect($this->_base_url);

--- a/third_party/purge/upd.purge.php
+++ b/third_party/purge/upd.purge.php
@@ -4,7 +4,7 @@
 
 class Purge_upd {
 	
-	public $version = '1.1';
+	public $version = '1.1.1';
 	
 	private $EE;
 	
@@ -37,6 +37,7 @@ class Purge_upd {
 		CREATE TABLE `{$this->EE->db->dbprefix}purge_rules` (
 			`id` int(11) unsigned NOT NULL auto_increment,
 			`channel_id` int(4) unsigned NOT NULL,
+			`site_id` int(4) unsigned NOT NULL,
 	 		`pattern` varchar(255) default NULL,
 			PRIMARY KEY  (`id`)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/third_party/purge/views/accessory_purge_varnish.php
+++ b/third_party/purge/views/accessory_purge_varnish.php
@@ -6,10 +6,6 @@
 <script type="text/javascript" charset="utf-8">
 	$(document).ready(function()
 	{
-		$('#purge_url').click(function()
-		{
-			if( ! $(this).val().match(/^\//) ) $(this).val('');
-		});
 		
 		$('#purge_varnish').click(function(event)
 		{
@@ -18,10 +14,10 @@
 			var url = $('#purge_url').val(); 
 			
 			if( url != '')
-			if( ! url.match(/^\/[^\/]/) ) { $('#purge_url').val('URL must start with one "/"'); return; }
+			if( ! url.match(/^\/[^\/]/) ) { alert('URL must start with one "/"'); return; }
 			
 			if( url == '' )
-			if( ! confirm('Are you sure you want to purge all cache? It may cause a cache stampede.') ) return;
+			if( ! confirm('Are you sure you want to purge all cache? It may cause a cache stampede during high traffic periods.') ) return;
 	
 			$('#purge_url').val('Sending purge request...');
 			

--- a/third_party/purge/views/accessory_purge_varnish.php
+++ b/third_party/purge/views/accessory_purge_varnish.php
@@ -1,21 +1,38 @@
-<a id="purge_varnish" href="#">Send purge request to Varnish now.</a>
-
+<small style="position:relative; top: -3px;">Enter URL starting with slash (not http etc) or leave blank to purge everything.</small><br>
+<div style="position:relative;">
+<input id="purge_url" type="text" style="width:350px; margin:0 3px 0 0;">
+<button id="purge_varnish" href="#" style="height:100%;position:absolute;">Purge</button>
+</div>
 <script type="text/javascript" charset="utf-8">
 	$(document).ready(function()
 	{
+		$('#purge_url').click(function()
+		{
+			if( ! $(this).val().match(/^\//) ) $(this).val('');
+		});
+		
 		$('#purge_varnish').click(function(event)
 		{
 			event.preventDefault();
 			
-			$link = $(this);
-			$link.html('Sending purge request...');
+			var url = $('#purge_url').val(); 
+			
+			if( url != '')
+			if( ! url.match(/^\/[^\/]/) ) { $('#purge_url').val('URL must start with one "/"'); return; }
+			
+			if( url == '' )
+			if( ! confirm('Are you sure you want to purge all cache? It may cause a cache stampede.') ) return;
+	
+			$('#purge_url').val('Sending purge request...');
 			
 			$.post("<?=$request_url?>",
 				{
+					purge_url: url,
 					XID: EE.XID
 				}, function(data)
 				{
-					$link.html('Request sent. Click to send another purge request.');
+					alert(data); 
+					$('#purge_url').val('');
 				}
 			);
 		});


### PR DESCRIPTION
Hey mate just some updates to the accessory because we wanted to be able to specify urls to clear also (when we just want to clear /css/styles.css for example). If blank old behavior applies. 

added gzip to curl - most browsers request gzip so the hash in varnish includes gzip. By sending purge request without gzip it likely won't clear the gzipped versions in cache. 
in accessory allow specify url or leave blank to clear all.
accessory now reports back varnish response OR curl error for better feedback.